### PR TITLE
Format and remove some allocations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,21 +18,21 @@ fn main() {
     let save_path_display = save_path.display();
 
     let part_1 = "# editorconfig.org\n\
-        \n\
-        root = true\n\
-        \n\
-        [*]\n\
-        end_of_line = lf\n\
-        charset = utf-8\n\
-        trim_trailing_whitespace = true\n\
-        insert_final_newline = true\n\
-        indent_style = space\n\
-        indent_size = ";
+\n\
+root = true\n\
+\n\
+[*]\n\
+end_of_line = lf\n\
+charset = utf-8\n\
+trim_trailing_whitespace = true\n\
+insert_final_newline = true\n\
+indent_style = space\n\
+indent_size = ";
 
     let part_2 = "\n\
-        \n\
-        [*.md]\n\
-        trim_trailing_whitespace = false\n";
+\n\
+[*.md]\n\
+trim_trailing_whitespace = false\n";
 
     let contents = part_1.to_owned() + argument_spaces + part_2;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,44 +7,43 @@ use std::io::prelude::*;
 fn main() {
     let args: Vec<String> = env::args().collect();
 
-    let mut argument_spaces = "2".to_string();
-    if args.len() == 2 {
-        argument_spaces = args[1].clone().to_string();
-    }
+    let argument_spaces = args.get(1).map(|x| x.as_str()).unwrap_or("2");
 
-    let mut argument_path = (".").to_string();
-    if args.len() == 3 {
-        argument_spaces = args[1].clone().to_string();
-        argument_path = args[2].clone().to_string();
-    }
+    let argument_path = args.get(2).map(|x| x.as_str()).unwrap_or(".");
 
     let file_name = "/.editorconfig";
-    let full_path = argument_path + &file_name;
+    let full_path = argument_path.to_owned() + file_name;
 
     let save_path = Path::new(&full_path);
     let save_path_display = save_path.display();
 
-    let part_1 = String::from("# editorconfig.org\n\
-\n\
-root = true\n\
-\n\
-[*]\n\
-end_of_line = lf\n\
-charset = utf-8\n\
-trim_trailing_whitespace = true\n\
-insert_final_newline = true\n\
-indent_style = space\n\
-indent_size = ");
+    let part_1 = "# editorconfig.org\n\
+        \n\
+        root = true\n\
+        \n\
+        [*]\n\
+        end_of_line = lf\n\
+        charset = utf-8\n\
+        trim_trailing_whitespace = true\n\
+        insert_final_newline = true\n\
+        indent_style = space\n\
+        indent_size = ";
 
-let part_2 = String::from("\n\
-\n\
-[*.md]\n\
-trim_trailing_whitespace = false\n");
+    let part_2 = "\n\
+        \n\
+        [*.md]\n\
+        trim_trailing_whitespace = false\n";
 
-    let contents = part_1 + &argument_spaces + &part_2;
+    let contents = part_1.to_owned() + argument_spaces + part_2;
 
     let mut output_file = match File::create(&save_path) {
-        Err(error) => panic!("Could not create {}: {}", save_path_display, error.description()),
+        Err(error) => {
+            panic!(
+                "Could not create {}: {}",
+                save_path_display,
+                error.description()
+            )
+        }
         Ok(file) => file,
     };
 


### PR DESCRIPTION
Formatted the code with rustfmt, and removed some `String` allocations by borrowing references from `args` with `get`.

I haven't tested this, but it should have no effect on the behaviour of the code.
